### PR TITLE
Fix publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -28,6 +28,7 @@ jobs:
           node-version: 20
           registry-url: https://registry.npmjs.org/
       - run: npm ci
+      - run: npm run build
       - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lookupdaily/styles",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "My style library and utilities",
   "main": "index.css",
   "files": [

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "My style library and utilities",
   "main": "index.css",
   "files": [
-    "src/**/*",
+    "scss/**/*",
     "index.css",
     "index.css.map",
     "package.json",


### PR DESCRIPTION
This fixes a few issues with the previous publish:

- The `npm run build` script is missing in the publish workflow
- The `scss` directory is not included in the packed files

Have also updated the version number for a new publish.