### PR TITLE
Fix mobile nav width

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lookupdaily/styles",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"description": "My style library and utilities",
 	"main": "dist/index.css",
 	"sass": "dist/index.scss",

--- a/scss/components/header/index.scss
+++ b/scss/components/header/index.scss
@@ -104,7 +104,6 @@
 
       &__list {
         flex-direction: column;
-        width: 100%;
         align-items: stretch;
         padding: 0;
       }
@@ -116,7 +115,6 @@
         justify-content: center;
         align-items: center;
         border-bottom: 1px solid var(--ld-colour-primary);
-        width: 100%;
       }
 
       &__link {


### PR DESCRIPTION
Remove 100% width on child elements: The combination of 100vw and padding causes any child elements with 100% width to run off.