### PR TITLE
Increment version number to v2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lookupdaily/styles",
-	"version": "1.1.1",
+	"version": "2.0.0",
 	"description": "My style library and utilities",
 	"main": "dist/index.css",
 	"sass": "dist/index.scss",


### PR DESCRIPTION
While this release will contain a relatively small change, it is a breaking one so incrementing by a major version.

Previously the use of the descriptive-list class required 3 elements per grid-row, with an icon in between the `<dt>` and `<dd>`. However, this fails WCAG criteria, so removing it from the class. 

Any usages of this class would need to ensure there are only pairs of `<dt>` and `<dd>` within the `<dl>` element with the class applied.