### PR TITLE
Fix alignment on footer

### DIFF
--- a/scss/components/_footer.scss
+++ b/scss/components/_footer.scss
@@ -26,8 +26,6 @@
 }
 
 .ld-social-links {
-  @include spacing.margin-bottom("small");
-
   display: flex;
   flex-direction: column;
 


### PR DESCRIPTION
On medium screens there are two columns on the footer - which had different margins applied causing them to be misaligned.