### PR TITLE
Add default export

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,20 +24,27 @@ npm i @lookupdaily/styles
 You can import the css file into your stylesheet
 
 ```css
-@import "@lookupdaily/styles/index.css";
+@import "@lookupdaily/styles";
 ```
 
 If your project uses sass you can import all styles, or individual modules
 
 ```scss
 /* Import all scss modules */
-@import "@lookupdaily/styles/scss";
+@use "@lookupdaily/styles/scss";
 
 /* Or the compiled css */
-@import "@lookupdaily/styles";
+@use "@lookupdaily/styles";
 
 /* Import individual scss modules */
-@import "lookupdaily/styles/scss/components/links";
+@use "lookupdaily/styles/scss/components/links";
+
+/* Import all scss modules and use mixins */
+@use "lookupdaily/styles/scss" as ld;
+
+.component {
+  @include ld.padding-top("small");
+}
 ```
 
 ## Styles

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Example:
   <button class="ld-header__menu-button" id="ld-menu-button" aria-expanded="false">
     <span class="ld-header__menu-button-text">Menu</span>
   </button>
-  <nav class="ld-header-nav" id="ld-menu" aria-labelledy="menu-label">
+  <nav class="ld-header-nav" id="ld-menu" aria-labelledby="menu-label">
     <ul class="ld-header-nav__list">
       <li class="ld-header-nav__item">
         <a class="ld-link ld-header-nav__link" href="/" data-state="active">

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
 	"sass": "dist/index.scss",
 	"css": "dist/index.css",
 	"exports": {
+		".": "./index.css",
 		"./header": "./dist/components/header/header.js",
 		"./header.js": "./dist/components/header/header.js",
 		"./scss/": "./dist/index.scss",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lookupdaily/styles",
-	"version": "2.0.1",
+	"version": "2.0.2",
 	"description": "My style library and utilities",
 	"main": "dist/index.css",
 	"sass": "dist/index.scss",


### PR DESCRIPTION
This removes the need to add the index.css file to the import in a stylesheet. Updating the instructions in the README accordingly to replace: 

```css
import "lookupdaily/styles/index.css";
```

with
```css
import "lookupdaily/styles";
```