### PR TITLE
Update to ESM modules

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,6 +1,0 @@
-module.exports = {
-	presets: [
-		["@babel/preset-env", { targets: { node: "current" } }],
-		"@babel/preset-typescript",
-	],
-};

--- a/biome.json
+++ b/biome.json
@@ -5,6 +5,7 @@
 	},
 	"linter": {
 		"enabled": true,
+		"ignore": ["jest.config.js"],
 		"rules": {
 			"all": true,
 			"nursery": {

--- a/biome.json
+++ b/biome.json
@@ -12,8 +12,7 @@
 				"all": false
 			},
 			"correctness": {
-				"noNodejsModules": "off",
-				"useImportExtensions": "off"
+				"noNodejsModules": "off"
 			}
 		}
 	},

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,4 +1,4 @@
-const gulp = require("gulp");
+import gulp from "gulp";
 
 const paths = {
 	pages: ["scss/**/*", "!scss/**/*.test.scss"],

--- a/jest.config.js
+++ b/jest.config.js
@@ -77,16 +77,16 @@ const config = {
 	// ],
 
 	// An array of file extensions your modules use
-	// moduleFileExtensions: [
-	//   "js",
-	//   "mjs",
-	//   "cjs",
-	//   "jsx",
-	//   "ts",
-	//   "tsx",
-	//   "json",
-	//   "node"
-	// ],
+	moduleFileExtensions: [
+		"js",
+		// "mjs",
+		// "cjs",
+		// "jsx",
+		"ts",
+		// "tsx",
+		"json",
+		// "node"
+	],
 
 	// A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
 	// moduleNameMapper: {},
@@ -113,6 +113,18 @@ const config = {
 			displayName: "dom",
 			testMatch: ["<rootDir>/src/**/*spec.*"],
 			testEnvironment: "jsdom",
+			transform: {
+				"\\.[jt]sx?$": [
+					"ts-jest",
+					{
+						useESM: true,
+					},
+				],
+			},
+			moduleNameMapper: {
+				"(.+)\\.js": "$1",
+			},
+			extensionsToTreatAsEsm: [".ts"],
 		},
 	],
 	testEnvironment: "node",

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,7 +4,7 @@
  */
 
 /** @type {import('jest').Config} */
-const config = {
+export default {
 	// All imported modules in your tests should be mocked automatically
 	// automock: false,
 
@@ -215,5 +215,3 @@ const config = {
 	// Whether to use watchman for file crawling
 	// watchman: true,
 };
-
-module.exports = config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,15 +9,11 @@
 			"version": "2.0.2",
 			"license": "ISC",
 			"devDependencies": {
-				"@babel/core": "^7.25.2",
-				"@babel/preset-env": "^7.25.4",
-				"@babel/preset-typescript": "^7.24.7",
 				"@biomejs/biome": "1.9.4",
 				"@testing-library/dom": "^10.4.0",
 				"@testing-library/jest-dom": "^6.5.0",
 				"@testing-library/user-event": "^14.5.2",
-				"@types/jest": "^29.5.13",
-				"babel-jest": "^29.7.0",
+				"@types/jest": "^29.5.14",
 				"glob": "^11.0.0",
 				"gulp": "^5.0.0",
 				"gulp-cli": "^3.0.0",
@@ -28,7 +24,8 @@
 				"sass-true": "^8.0.0",
 				"stylelint": "^16.8.1",
 				"stylelint-config-standard-scss": "^13.1.0",
-				"typescript": "^5.6.2"
+				"ts-jest": "^29.2.5",
+				"typescript": "^5.7.2"
 			}
 		},
 		"node_modules/@adobe/css-tools": {
@@ -125,33 +122,6 @@
 				"node": ">=6.9.0"
 			}
 		},
-		"node_modules/@babel/helper-annotate-as-pure": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.25.9.tgz",
-			"integrity": "sha512-gv7320KBUFJz1RnylIg5WWYPRXKZ884AGkYpgpWW02TH66Dl+HaC1t1CKd0z3R4b6hdYEcmrNZHUmfCP+1u3/g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/types": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/helper-builder-binary-assignment-operator-visitor": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.25.9.tgz",
-			"integrity": "sha512-C47lC7LIDCnz0h4vai/tpNOI95tCd5ZT3iBt/DBH5lXKHZsyNQv18yf1wIIg2ntiQNgmAvA+DgZ82iW8Qdym8g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/traverse": "^7.25.9",
-				"@babel/types": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
 		"node_modules/@babel/helper-compilation-targets": {
 			"version": "7.25.9",
 			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.9.tgz",
@@ -164,77 +134,6 @@
 				"browserslist": "^4.24.0",
 				"lru-cache": "^5.1.1",
 				"semver": "^6.3.1"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/helper-create-class-features-plugin": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.25.9.tgz",
-			"integrity": "sha512-UTZQMvt0d/rSz6KI+qdu7GQze5TIajwTS++GUozlw8VBJDEOAqSXwm1WvmYEZwqdqSGQshRocPDqrt4HBZB3fQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-annotate-as-pure": "^7.25.9",
-				"@babel/helper-member-expression-to-functions": "^7.25.9",
-				"@babel/helper-optimise-call-expression": "^7.25.9",
-				"@babel/helper-replace-supers": "^7.25.9",
-				"@babel/helper-skip-transparent-expression-wrappers": "^7.25.9",
-				"@babel/traverse": "^7.25.9",
-				"semver": "^6.3.1"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0"
-			}
-		},
-		"node_modules/@babel/helper-create-regexp-features-plugin": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.25.9.tgz",
-			"integrity": "sha512-ORPNZ3h6ZRkOyAa/SaHU+XsLZr0UQzRwuDQ0cczIA17nAzZ+85G5cVkOJIj7QavLZGSe8QXUmNFxSZzjcZF9bw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-annotate-as-pure": "^7.25.9",
-				"regexpu-core": "^6.1.1",
-				"semver": "^6.3.1"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0"
-			}
-		},
-		"node_modules/@babel/helper-define-polyfill-provider": {
-			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.2.tgz",
-			"integrity": "sha512-LV76g+C502biUK6AyZ3LK10vDpDyCzZnhZFXkH1L75zHPj68+qc8Zfpx2th+gzwA2MzyK+1g/3EPl62yFnVttQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-compilation-targets": "^7.22.6",
-				"@babel/helper-plugin-utils": "^7.22.5",
-				"debug": "^4.1.1",
-				"lodash.debounce": "^4.0.8",
-				"resolve": "^1.14.2"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
-			}
-		},
-		"node_modules/@babel/helper-member-expression-to-functions": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.25.9.tgz",
-			"integrity": "sha512-wbfdZ9w5vk0C0oyHqAJbc62+vet5prjj01jjJ8sKn3j9h3MQQlflEdXYvuqRWjHnM12coDEqiC1IRCi0U/EKwQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/traverse": "^7.25.9",
-				"@babel/types": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -272,89 +171,12 @@
 				"@babel/core": "^7.0.0"
 			}
 		},
-		"node_modules/@babel/helper-optimise-call-expression": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.25.9.tgz",
-			"integrity": "sha512-FIpuNaz5ow8VyrYcnXQTDRGvV6tTjkNtCK/RYNDXGSLlUD6cBuQTSw43CShGxjvfBTfcUA/r6UhUCbtYqkhcuQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/types": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
 		"node_modules/@babel/helper-plugin-utils": {
 			"version": "7.25.9",
 			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.25.9.tgz",
 			"integrity": "sha512-kSMlyUVdWe25rEsRGviIgOWnoT/nfABVWlqt9N19/dIPWViAOW2s9wznP5tURbs/IDuNk4gPy3YdYRgH3uxhBw==",
 			"dev": true,
 			"license": "MIT",
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/helper-remap-async-to-generator": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.25.9.tgz",
-			"integrity": "sha512-IZtukuUeBbhgOcaW2s06OXTzVNJR0ybm4W5xC1opWFFJMZbwRj5LCk+ByYH7WdZPZTt8KnFwA8pvjN2yqcPlgw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-annotate-as-pure": "^7.25.9",
-				"@babel/helper-wrap-function": "^7.25.9",
-				"@babel/traverse": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0"
-			}
-		},
-		"node_modules/@babel/helper-replace-supers": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.25.9.tgz",
-			"integrity": "sha512-IiDqTOTBQy0sWyeXyGSC5TBJpGFXBkRynjBeXsvbhQFKj2viwJC76Epz35YLU1fpe/Am6Vppb7W7zM4fPQzLsQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-member-expression-to-functions": "^7.25.9",
-				"@babel/helper-optimise-call-expression": "^7.25.9",
-				"@babel/traverse": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0"
-			}
-		},
-		"node_modules/@babel/helper-simple-access": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.25.9.tgz",
-			"integrity": "sha512-c6WHXuiaRsJTyHYLJV75t9IqsmTbItYfdj99PnzYGQZkYKvan5/2jKJ7gu31J3/BJ/A18grImSPModuyG/Eo0Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/traverse": "^7.25.9",
-				"@babel/types": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/helper-skip-transparent-expression-wrappers": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.25.9.tgz",
-			"integrity": "sha512-K4Du3BFa3gvyhzgPcntrkDgZzQaq6uozzcpGbOO1OEJaI+EJdqWIMTLgFgQf6lrfiDFo5FU+BxKepI9RmZqahA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/traverse": "^7.25.9",
-				"@babel/types": "^7.25.9"
-			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -389,21 +211,6 @@
 				"node": ">=6.9.0"
 			}
 		},
-		"node_modules/@babel/helper-wrap-function": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.25.9.tgz",
-			"integrity": "sha512-ETzz9UTjQSTmw39GboatdymDq4XIQbR8ySgVrylRhPOFpsd+JrKHIuF0de7GCWmem+T4uC5z7EZguod7Wj4A4g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/template": "^7.25.9",
-				"@babel/traverse": "^7.25.9",
-				"@babel/types": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
 		"node_modules/@babel/helpers": {
 			"version": "7.26.0",
 			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.0.tgz",
@@ -432,103 +239,6 @@
 			},
 			"engines": {
 				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.25.9.tgz",
-			"integrity": "sha512-ZkRyVkThtxQ/J6nv3JFYv1RYY+JT5BvU0y3k5bWrmuG4woXypRa4PXmm9RhOwodRkYFWqC0C0cqcJ4OqR7kW+g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9",
-				"@babel/traverse": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0"
-			}
-		},
-		"node_modules/@babel/plugin-bugfix-safari-class-field-initializer-scope": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.25.9.tgz",
-			"integrity": "sha512-MrGRLZxLD/Zjj0gdU15dfs+HH/OXvnw/U4jJD8vpcP2CJQapPEv1IWwjc/qMg7ItBlPwSv1hRBbb7LeuANdcnw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0"
-			}
-		},
-		"node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.25.9.tgz",
-			"integrity": "sha512-2qUwwfAFpJLZqxd02YW9btUCZHl+RFvdDkNfZwaIJrvB8Tesjsk8pEQkTvGwZXLqXUx/2oyY3ySRhm6HOXuCug==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0"
-			}
-		},
-		"node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.25.9.tgz",
-			"integrity": "sha512-6xWgLZTJXwilVjlnV7ospI3xi+sl8lN8rXXbBD6vYn3UYDlGsag8wrZkKcSI8G6KgqKP7vNFaDgeDnfAABq61g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9",
-				"@babel/helper-skip-transparent-expression-wrappers": "^7.25.9",
-				"@babel/plugin-transform-optional-chaining": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.13.0"
-			}
-		},
-		"node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.25.9.tgz",
-			"integrity": "sha512-aLnMXYPnzwwqhYSCyXfKkIkYgJ8zv9RK+roo9DkTXz38ynIhd9XCbN08s3MGvqL2MYGVUGdRQLL/JqBIeJhJBg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9",
-				"@babel/traverse": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0"
-			}
-		},
-		"node_modules/@babel/plugin-proposal-private-property-in-object": {
-			"version": "7.21.0-placeholder-for-preset-env.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
-			"integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
 			}
 		},
 		"node_modules/@babel/plugin-syntax-async-generators": {
@@ -565,38 +275,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.12.13"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-syntax-import-assertions": {
-			"version": "7.26.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.26.0.tgz",
-			"integrity": "sha512-QCWT5Hh830hK5EQa7XzuqIkQU9tT/whqbDz7kuaZMHFl1inRRg7JnuAEOQ0Ur0QUl0NufCk1msK2BeY79Aj/eg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-syntax-import-attributes": {
-			"version": "7.26.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.26.0.tgz",
-			"integrity": "sha512-e2dttdsJ1ZTpi3B9UYGLw41hifAubg19AtCu/2I/F1QNVclOBr1dYpTdmdyZ84Xiz43BS/tCUkMAZNLv12Pi+A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.0.0-0"
@@ -746,1001 +424,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-syntax-unicode-sets-regex": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-unicode-sets-regex/-/plugin-syntax-unicode-sets-regex-7.18.6.tgz",
-			"integrity": "sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-create-regexp-features-plugin": "^7.18.6",
-				"@babel/helper-plugin-utils": "^7.18.6"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-arrow-functions": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.25.9.tgz",
-			"integrity": "sha512-6jmooXYIwn9ca5/RylZADJ+EnSxVUS5sjeJ9UPk6RWRzXCmOJCy6dqItPJFpw2cuCangPK4OYr5uhGKcmrm5Qg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-async-generator-functions": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.25.9.tgz",
-			"integrity": "sha512-RXV6QAzTBbhDMO9fWwOmwwTuYaiPbggWQ9INdZqAYeSHyG7FzQ+nOZaUUjNwKv9pV3aE4WFqFm1Hnbci5tBCAw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9",
-				"@babel/helper-remap-async-to-generator": "^7.25.9",
-				"@babel/traverse": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-async-to-generator": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.25.9.tgz",
-			"integrity": "sha512-NT7Ejn7Z/LjUH0Gv5KsBCxh7BH3fbLTV0ptHvpeMvrt3cPThHfJfst9Wrb7S8EvJ7vRTFI7z+VAvFVEQn/m5zQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-module-imports": "^7.25.9",
-				"@babel/helper-plugin-utils": "^7.25.9",
-				"@babel/helper-remap-async-to-generator": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-block-scoped-functions": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.25.9.tgz",
-			"integrity": "sha512-toHc9fzab0ZfenFpsyYinOX0J/5dgJVA2fm64xPewu7CoYHWEivIWKxkK2rMi4r3yQqLnVmheMXRdG+k239CgA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-block-scoping": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.25.9.tgz",
-			"integrity": "sha512-1F05O7AYjymAtqbsFETboN1NvBdcnzMerO+zlMyJBEz6WkMdejvGWw9p05iTSjC85RLlBseHHQpYaM4gzJkBGg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-class-properties": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.25.9.tgz",
-			"integrity": "sha512-bbMAII8GRSkcd0h0b4X+36GksxuheLFjP65ul9w6C3KgAamI3JqErNgSrosX6ZPj+Mpim5VvEbawXxJCyEUV3Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-create-class-features-plugin": "^7.25.9",
-				"@babel/helper-plugin-utils": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-class-static-block": {
-			"version": "7.26.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.26.0.tgz",
-			"integrity": "sha512-6J2APTs7BDDm+UMqP1useWqhcRAXo0WIoVj26N7kPFB6S73Lgvyka4KTZYIxtgYXiN5HTyRObA72N2iu628iTQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-create-class-features-plugin": "^7.25.9",
-				"@babel/helper-plugin-utils": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.12.0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-classes": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.25.9.tgz",
-			"integrity": "sha512-mD8APIXmseE7oZvZgGABDyM34GUmK45Um2TXiBUt7PnuAxrgoSVf123qUzPxEr/+/BHrRn5NMZCdE2m/1F8DGg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-annotate-as-pure": "^7.25.9",
-				"@babel/helper-compilation-targets": "^7.25.9",
-				"@babel/helper-plugin-utils": "^7.25.9",
-				"@babel/helper-replace-supers": "^7.25.9",
-				"@babel/traverse": "^7.25.9",
-				"globals": "^11.1.0"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-computed-properties": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.25.9.tgz",
-			"integrity": "sha512-HnBegGqXZR12xbcTHlJ9HGxw1OniltT26J5YpfruGqtUHlz/xKf/G2ak9e+t0rVqrjXa9WOhvYPz1ERfMj23AA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9",
-				"@babel/template": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-destructuring": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.25.9.tgz",
-			"integrity": "sha512-WkCGb/3ZxXepmMiX101nnGiU+1CAdut8oHyEOHxkKuS1qKpU2SMXE2uSvfz8PBuLd49V6LEsbtyPhWC7fnkgvQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-dotall-regex": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.25.9.tgz",
-			"integrity": "sha512-t7ZQ7g5trIgSRYhI9pIJtRl64KHotutUJsh4Eze5l7olJv+mRSg4/MmbZ0tv1eeqRbdvo/+trvJD/Oc5DmW2cA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-create-regexp-features-plugin": "^7.25.9",
-				"@babel/helper-plugin-utils": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-duplicate-keys": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.25.9.tgz",
-			"integrity": "sha512-LZxhJ6dvBb/f3x8xwWIuyiAHy56nrRG3PeYTpBkkzkYRRQ6tJLu68lEF5VIqMUZiAV7a8+Tb78nEoMCMcqjXBw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.25.9.tgz",
-			"integrity": "sha512-0UfuJS0EsXbRvKnwcLjFtJy/Sxc5J5jhLHnFhy7u4zih97Hz6tJkLU+O+FMMrNZrosUPxDi6sYxJ/EA8jDiAog==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-create-regexp-features-plugin": "^7.25.9",
-				"@babel/helper-plugin-utils": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-dynamic-import": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.25.9.tgz",
-			"integrity": "sha512-GCggjexbmSLaFhqsojeugBpeaRIgWNTcgKVq/0qIteFEqY2A+b9QidYadrWlnbWQUrW5fn+mCvf3tr7OeBFTyg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-exponentiation-operator": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.25.9.tgz",
-			"integrity": "sha512-KRhdhlVk2nObA5AYa7QMgTMTVJdfHprfpAk4DjZVtllqRg9qarilstTKEhpVjyt+Npi8ThRyiV8176Am3CodPA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-builder-binary-assignment-operator-visitor": "^7.25.9",
-				"@babel/helper-plugin-utils": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-export-namespace-from": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.25.9.tgz",
-			"integrity": "sha512-2NsEz+CxzJIVOPx2o9UsW1rXLqtChtLoVnwYHHiB04wS5sgn7mrV45fWMBX0Kk+ub9uXytVYfNP2HjbVbCB3Ww==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-for-of": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.25.9.tgz",
-			"integrity": "sha512-LqHxduHoaGELJl2uhImHwRQudhCM50pT46rIBNvtT/Oql3nqiS3wOwP+5ten7NpYSXrrVLgtZU3DZmPtWZo16A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9",
-				"@babel/helper-skip-transparent-expression-wrappers": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-function-name": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.25.9.tgz",
-			"integrity": "sha512-8lP+Yxjv14Vc5MuWBpJsoUCd3hD6V9DgBon2FVYL4jJgbnVQ9fTgYmonchzZJOVNgzEgbxp4OwAf6xz6M/14XA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-compilation-targets": "^7.25.9",
-				"@babel/helper-plugin-utils": "^7.25.9",
-				"@babel/traverse": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-json-strings": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.25.9.tgz",
-			"integrity": "sha512-xoTMk0WXceiiIvsaquQQUaLLXSW1KJ159KP87VilruQm0LNNGxWzahxSS6T6i4Zg3ezp4vA4zuwiNUR53qmQAw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-literals": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.25.9.tgz",
-			"integrity": "sha512-9N7+2lFziW8W9pBl2TzaNht3+pgMIRP74zizeCSrtnSKVdUl8mAjjOP2OOVQAfZ881P2cNjDj1uAMEdeD50nuQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-logical-assignment-operators": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.25.9.tgz",
-			"integrity": "sha512-wI4wRAzGko551Y8eVf6iOY9EouIDTtPb0ByZx+ktDGHwv6bHFimrgJM/2T021txPZ2s4c7bqvHbd+vXG6K948Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-member-expression-literals": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.25.9.tgz",
-			"integrity": "sha512-PYazBVfofCQkkMzh2P6IdIUaCEWni3iYEerAsRWuVd8+jlM1S9S9cz1dF9hIzyoZ8IA3+OwVYIp9v9e+GbgZhA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-modules-amd": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.25.9.tgz",
-			"integrity": "sha512-g5T11tnI36jVClQlMlt4qKDLlWnG5pP9CSM4GhdRciTNMRgkfpo5cR6b4rGIOYPgRRuFAvwjPQ/Yk+ql4dyhbw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-module-transforms": "^7.25.9",
-				"@babel/helper-plugin-utils": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-modules-commonjs": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.25.9.tgz",
-			"integrity": "sha512-dwh2Ol1jWwL2MgkCzUSOvfmKElqQcuswAZypBSUsScMXvgdT8Ekq5YA6TtqpTVWH+4903NmboMuH1o9i8Rxlyg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-module-transforms": "^7.25.9",
-				"@babel/helper-plugin-utils": "^7.25.9",
-				"@babel/helper-simple-access": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-modules-systemjs": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.25.9.tgz",
-			"integrity": "sha512-hyss7iIlH/zLHaehT+xwiymtPOpsiwIIRlCAOwBB04ta5Tt+lNItADdlXw3jAWZ96VJ2jlhl/c+PNIQPKNfvcA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-module-transforms": "^7.25.9",
-				"@babel/helper-plugin-utils": "^7.25.9",
-				"@babel/helper-validator-identifier": "^7.25.9",
-				"@babel/traverse": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-modules-umd": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.25.9.tgz",
-			"integrity": "sha512-bS9MVObUgE7ww36HEfwe6g9WakQ0KF07mQF74uuXdkoziUPfKyu/nIm663kz//e5O1nPInPFx36z7WJmJ4yNEw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-module-transforms": "^7.25.9",
-				"@babel/helper-plugin-utils": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.25.9.tgz",
-			"integrity": "sha512-oqB6WHdKTGl3q/ItQhpLSnWWOpjUJLsOCLVyeFgeTktkBSCiurvPOsyt93gibI9CmuKvTUEtWmG5VhZD+5T/KA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-create-regexp-features-plugin": "^7.25.9",
-				"@babel/helper-plugin-utils": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-new-target": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.25.9.tgz",
-			"integrity": "sha512-U/3p8X1yCSoKyUj2eOBIx3FOn6pElFOKvAAGf8HTtItuPyB+ZeOqfn+mvTtg9ZlOAjsPdK3ayQEjqHjU/yLeVQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.25.9.tgz",
-			"integrity": "sha512-ENfftpLZw5EItALAD4WsY/KUWvhUlZndm5GC7G3evUsVeSJB6p0pBeLQUnRnBCBx7zV0RKQjR9kCuwrsIrjWog==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-numeric-separator": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.25.9.tgz",
-			"integrity": "sha512-TlprrJ1GBZ3r6s96Yq8gEQv82s8/5HnCVHtEJScUj90thHQbwe+E5MLhi2bbNHBEJuzrvltXSru+BUxHDoog7Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-object-rest-spread": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.25.9.tgz",
-			"integrity": "sha512-fSaXafEE9CVHPweLYw4J0emp1t8zYTXyzN3UuG+lylqkvYd7RMrsOQ8TYx5RF231be0vqtFC6jnx3UmpJmKBYg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-compilation-targets": "^7.25.9",
-				"@babel/helper-plugin-utils": "^7.25.9",
-				"@babel/plugin-transform-parameters": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-object-super": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.25.9.tgz",
-			"integrity": "sha512-Kj/Gh+Rw2RNLbCK1VAWj2U48yxxqL2x0k10nPtSdRa0O2xnHXalD0s+o1A6a0W43gJ00ANo38jxkQreckOzv5A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9",
-				"@babel/helper-replace-supers": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-optional-catch-binding": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.25.9.tgz",
-			"integrity": "sha512-qM/6m6hQZzDcZF3onzIhZeDHDO43bkNNlOX0i8n3lR6zLbu0GN2d8qfM/IERJZYauhAHSLHy39NF0Ctdvcid7g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-optional-chaining": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.25.9.tgz",
-			"integrity": "sha512-6AvV0FsLULbpnXeBjrY4dmWF8F7gf8QnvTEoO/wX/5xm/xE1Xo8oPuD3MPS+KS9f9XBEAWN7X1aWr4z9HdOr7A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9",
-				"@babel/helper-skip-transparent-expression-wrappers": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-parameters": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.25.9.tgz",
-			"integrity": "sha512-wzz6MKwpnshBAiRmn4jR8LYz/g8Ksg0o80XmwZDlordjwEk9SxBzTWC7F5ef1jhbrbOW2DJ5J6ayRukrJmnr0g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-private-methods": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.25.9.tgz",
-			"integrity": "sha512-D/JUozNpQLAPUVusvqMxyvjzllRaF8/nSrP1s2YGQT/W4LHK4xxsMcHjhOGTS01mp9Hda8nswb+FblLdJornQw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-create-class-features-plugin": "^7.25.9",
-				"@babel/helper-plugin-utils": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-private-property-in-object": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.25.9.tgz",
-			"integrity": "sha512-Evf3kcMqzXA3xfYJmZ9Pg1OvKdtqsDMSWBDzZOPLvHiTt36E75jLDQo5w1gtRU95Q4E5PDttrTf25Fw8d/uWLw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-annotate-as-pure": "^7.25.9",
-				"@babel/helper-create-class-features-plugin": "^7.25.9",
-				"@babel/helper-plugin-utils": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-property-literals": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.25.9.tgz",
-			"integrity": "sha512-IvIUeV5KrS/VPavfSM/Iu+RE6llrHrYIKY1yfCzyO/lMXHQ+p7uGhonmGVisv6tSBSVgWzMBohTcvkC9vQcQFA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-regenerator": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.25.9.tgz",
-			"integrity": "sha512-vwDcDNsgMPDGP0nMqzahDWE5/MLcX8sv96+wfX7as7LoF/kr97Bo/7fI00lXY4wUXYfVmwIIyG80fGZ1uvt2qg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9",
-				"regenerator-transform": "^0.15.2"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-regexp-modifiers": {
-			"version": "7.26.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.26.0.tgz",
-			"integrity": "sha512-vN6saax7lrA2yA/Pak3sCxuD6F5InBjn9IcrIKQPjpsLvuHYLVroTxjdlVRHjjBWxKOqIwpTXDkOssYT4BFdRw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-create-regexp-features-plugin": "^7.25.9",
-				"@babel/helper-plugin-utils": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-reserved-words": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.25.9.tgz",
-			"integrity": "sha512-7DL7DKYjn5Su++4RXu8puKZm2XBPHyjWLUidaPEkCUBbE7IPcsrkRHggAOOKydH1dASWdcUBxrkOGNxUv5P3Jg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-shorthand-properties": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.25.9.tgz",
-			"integrity": "sha512-MUv6t0FhO5qHnS/W8XCbHmiRWOphNufpE1IVxhK5kuN3Td9FT1x4rx4K42s3RYdMXCXpfWkGSbCSd0Z64xA7Ng==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-spread": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.25.9.tgz",
-			"integrity": "sha512-oNknIB0TbURU5pqJFVbOOFspVlrpVwo2H1+HUIsVDvp5VauGGDP1ZEvO8Nn5xyMEs3dakajOxlmkNW7kNgSm6A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9",
-				"@babel/helper-skip-transparent-expression-wrappers": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-sticky-regex": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.25.9.tgz",
-			"integrity": "sha512-WqBUSgeVwucYDP9U/xNRQam7xV8W5Zf+6Eo7T2SRVUFlhRiMNFdFz58u0KZmCVVqs2i7SHgpRnAhzRNmKfi2uA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-template-literals": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.25.9.tgz",
-			"integrity": "sha512-o97AE4syN71M/lxrCtQByzphAdlYluKPDBzDVzMmfCobUjjhAryZV0AIpRPrxN0eAkxXO6ZLEScmt+PNhj2OTw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-typeof-symbol": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.25.9.tgz",
-			"integrity": "sha512-v61XqUMiueJROUv66BVIOi0Fv/CUuZuZMl5NkRoCVxLAnMexZ0A3kMe7vvZ0nulxMuMp0Mk6S5hNh48yki08ZA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-typescript": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.25.9.tgz",
-			"integrity": "sha512-7PbZQZP50tzv2KGGnhh82GSyMB01yKY9scIjf1a+GfZCtInOWqUH5+1EBU4t9fyR5Oykkkc9vFTs4OHrhHXljQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-annotate-as-pure": "^7.25.9",
-				"@babel/helper-create-class-features-plugin": "^7.25.9",
-				"@babel/helper-plugin-utils": "^7.25.9",
-				"@babel/helper-skip-transparent-expression-wrappers": "^7.25.9",
-				"@babel/plugin-syntax-typescript": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-unicode-escapes": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.25.9.tgz",
-			"integrity": "sha512-s5EDrE6bW97LtxOcGj1Khcx5AaXwiMmi4toFWRDP9/y0Woo6pXC+iyPu/KuhKtfSrNFd7jJB+/fkOtZy6aIC6Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-unicode-property-regex": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.25.9.tgz",
-			"integrity": "sha512-Jt2d8Ga+QwRluxRQ307Vlxa6dMrYEMZCgGxoPR8V52rxPyldHu3hdlHspxaqYmE7oID5+kB+UKUB/eWS+DkkWg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-create-regexp-features-plugin": "^7.25.9",
-				"@babel/helper-plugin-utils": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-unicode-regex": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.25.9.tgz",
-			"integrity": "sha512-yoxstj7Rg9dlNn9UQxzk4fcNivwv4nUYz7fYXBaKxvw/lnmPuOm/ikoELygbYq68Bls3D/D+NBPHiLwZdZZ4HA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-create-regexp-features-plugin": "^7.25.9",
-				"@babel/helper-plugin-utils": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-transform-unicode-sets-regex": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.25.9.tgz",
-			"integrity": "sha512-8BYqO3GeVNHtx69fdPshN3fnzUNLrWdHhk/icSwigksJGczKSizZ+Z6SBCxTs723Fr5VSNorTIK7a+R2tISvwQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-create-regexp-features-plugin": "^7.25.9",
-				"@babel/helper-plugin-utils": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0"
-			}
-		},
-		"node_modules/@babel/preset-env": {
-			"version": "7.26.0",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.26.0.tgz",
-			"integrity": "sha512-H84Fxq0CQJNdPFT2DrfnylZ3cf5K43rGfWK4LJGPpjKHiZlk0/RzwEus3PDDZZg+/Er7lCA03MVacueUuXdzfw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/compat-data": "^7.26.0",
-				"@babel/helper-compilation-targets": "^7.25.9",
-				"@babel/helper-plugin-utils": "^7.25.9",
-				"@babel/helper-validator-option": "^7.25.9",
-				"@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.25.9",
-				"@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.25.9",
-				"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.25.9",
-				"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.25.9",
-				"@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.25.9",
-				"@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
-				"@babel/plugin-syntax-import-assertions": "^7.26.0",
-				"@babel/plugin-syntax-import-attributes": "^7.26.0",
-				"@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
-				"@babel/plugin-transform-arrow-functions": "^7.25.9",
-				"@babel/plugin-transform-async-generator-functions": "^7.25.9",
-				"@babel/plugin-transform-async-to-generator": "^7.25.9",
-				"@babel/plugin-transform-block-scoped-functions": "^7.25.9",
-				"@babel/plugin-transform-block-scoping": "^7.25.9",
-				"@babel/plugin-transform-class-properties": "^7.25.9",
-				"@babel/plugin-transform-class-static-block": "^7.26.0",
-				"@babel/plugin-transform-classes": "^7.25.9",
-				"@babel/plugin-transform-computed-properties": "^7.25.9",
-				"@babel/plugin-transform-destructuring": "^7.25.9",
-				"@babel/plugin-transform-dotall-regex": "^7.25.9",
-				"@babel/plugin-transform-duplicate-keys": "^7.25.9",
-				"@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.25.9",
-				"@babel/plugin-transform-dynamic-import": "^7.25.9",
-				"@babel/plugin-transform-exponentiation-operator": "^7.25.9",
-				"@babel/plugin-transform-export-namespace-from": "^7.25.9",
-				"@babel/plugin-transform-for-of": "^7.25.9",
-				"@babel/plugin-transform-function-name": "^7.25.9",
-				"@babel/plugin-transform-json-strings": "^7.25.9",
-				"@babel/plugin-transform-literals": "^7.25.9",
-				"@babel/plugin-transform-logical-assignment-operators": "^7.25.9",
-				"@babel/plugin-transform-member-expression-literals": "^7.25.9",
-				"@babel/plugin-transform-modules-amd": "^7.25.9",
-				"@babel/plugin-transform-modules-commonjs": "^7.25.9",
-				"@babel/plugin-transform-modules-systemjs": "^7.25.9",
-				"@babel/plugin-transform-modules-umd": "^7.25.9",
-				"@babel/plugin-transform-named-capturing-groups-regex": "^7.25.9",
-				"@babel/plugin-transform-new-target": "^7.25.9",
-				"@babel/plugin-transform-nullish-coalescing-operator": "^7.25.9",
-				"@babel/plugin-transform-numeric-separator": "^7.25.9",
-				"@babel/plugin-transform-object-rest-spread": "^7.25.9",
-				"@babel/plugin-transform-object-super": "^7.25.9",
-				"@babel/plugin-transform-optional-catch-binding": "^7.25.9",
-				"@babel/plugin-transform-optional-chaining": "^7.25.9",
-				"@babel/plugin-transform-parameters": "^7.25.9",
-				"@babel/plugin-transform-private-methods": "^7.25.9",
-				"@babel/plugin-transform-private-property-in-object": "^7.25.9",
-				"@babel/plugin-transform-property-literals": "^7.25.9",
-				"@babel/plugin-transform-regenerator": "^7.25.9",
-				"@babel/plugin-transform-regexp-modifiers": "^7.26.0",
-				"@babel/plugin-transform-reserved-words": "^7.25.9",
-				"@babel/plugin-transform-shorthand-properties": "^7.25.9",
-				"@babel/plugin-transform-spread": "^7.25.9",
-				"@babel/plugin-transform-sticky-regex": "^7.25.9",
-				"@babel/plugin-transform-template-literals": "^7.25.9",
-				"@babel/plugin-transform-typeof-symbol": "^7.25.9",
-				"@babel/plugin-transform-unicode-escapes": "^7.25.9",
-				"@babel/plugin-transform-unicode-property-regex": "^7.25.9",
-				"@babel/plugin-transform-unicode-regex": "^7.25.9",
-				"@babel/plugin-transform-unicode-sets-regex": "^7.25.9",
-				"@babel/preset-modules": "0.1.6-no-external-plugins",
-				"babel-plugin-polyfill-corejs2": "^0.4.10",
-				"babel-plugin-polyfill-corejs3": "^0.10.6",
-				"babel-plugin-polyfill-regenerator": "^0.6.1",
-				"core-js-compat": "^3.38.1",
-				"semver": "^6.3.1"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/preset-modules": {
-			"version": "0.1.6-no-external-plugins",
-			"resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.6-no-external-plugins.tgz",
-			"integrity": "sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/types": "^7.4.4",
-				"esutils": "^2.0.2"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0 || ^8.0.0-0 <8.0.0"
-			}
-		},
-		"node_modules/@babel/preset-typescript": {
-			"version": "7.26.0",
-			"resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.26.0.tgz",
-			"integrity": "sha512-NMk1IGZ5I/oHhoXEElcm+xUnL/szL6xflkFZmoEU9xj1qSJXpiS7rsspYo92B4DRCDvZn2erT5LdsCeXAKNCkg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9",
-				"@babel/helper-validator-option": "^7.25.9",
-				"@babel/plugin-syntax-jsx": "^7.25.9",
-				"@babel/plugin-transform-modules-commonjs": "^7.25.9",
-				"@babel/plugin-transform-typescript": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -3554,6 +2237,13 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/async": {
+			"version": "3.2.6",
+			"resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+			"integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/async-done": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/async-done/-/async-done-2.0.0.tgz",
@@ -3683,48 +2373,6 @@
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/babel-plugin-polyfill-corejs2": {
-			"version": "0.4.11",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.11.tgz",
-			"integrity": "sha512-sMEJ27L0gRHShOh5G54uAAPaiCOygY/5ratXuiyb2G46FmlSpc9eFCzYVyDiPxfNbwzA7mYahmjQc5q+CZQ09Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/compat-data": "^7.22.6",
-				"@babel/helper-define-polyfill-provider": "^0.6.2",
-				"semver": "^6.3.1"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
-			}
-		},
-		"node_modules/babel-plugin-polyfill-corejs3": {
-			"version": "0.10.6",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.10.6.tgz",
-			"integrity": "sha512-b37+KR2i/khY5sKmWNVQAnitvquQbNdWy6lJdsr0kmquCKEEUgMKK4SboVM3HtfnZilfjr4MMQ7vY58FVWDtIA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-define-polyfill-provider": "^0.6.2",
-				"core-js-compat": "^3.38.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
-			}
-		},
-		"node_modules/babel-plugin-polyfill-regenerator": {
-			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.2.tgz",
-			"integrity": "sha512-2R25rQZWP63nGwaAswvDazbPXfrM3HwVoBXK6HcqeKrSrL/JqcC/rDcf95l4r7LXLyxDXc8uQDa064GubtCABg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-define-polyfill-provider": "^0.6.2"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
 			}
 		},
 		"node_modules/babel-preset-current-node-syntax": {
@@ -3905,6 +2553,19 @@
 			},
 			"engines": {
 				"node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+			}
+		},
+		"node_modules/bs-logger": {
+			"version": "0.2.6",
+			"resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+			"integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-json-stable-stringify": "2.x"
+			},
+			"engines": {
+				"node": ">= 6"
 			}
 		},
 		"node_modules/bser": {
@@ -4219,20 +2880,6 @@
 			},
 			"engines": {
 				"node": ">= 10.13.0"
-			}
-		},
-		"node_modules/core-js-compat": {
-			"version": "3.38.1",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.38.1.tgz",
-			"integrity": "sha512-JRH6gfXxGmrzF3tZ57lFx97YARxCXPaMzPo6jELZhv88pBH5VXpQ+y0znKGlFnzuaihqhLbefxSJxWJMPtfDzw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"browserslist": "^4.23.3"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/core-js"
 			}
 		},
 		"node_modules/cosmiconfig": {
@@ -4562,6 +3209,22 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/ejs": {
+			"version": "3.1.10",
+			"resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+			"integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"jake": "^10.8.5"
+			},
+			"bin": {
+				"ejs": "bin/cli.js"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/electron-to-chromium": {
 			"version": "1.5.32",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.32.tgz",
@@ -4871,6 +3534,29 @@
 			},
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/filelist": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
+			"integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"minimatch": "^5.0.1"
+			}
+		},
+		"node_modules/filelist/node_modules/minimatch": {
+			"version": "5.1.6",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+			"integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/fill-range": {
@@ -5963,6 +4649,73 @@
 			},
 			"optionalDependencies": {
 				"@pkgjs/parseargs": "^0.11.0"
+			}
+		},
+		"node_modules/jake": {
+			"version": "10.9.2",
+			"resolved": "https://registry.npmjs.org/jake/-/jake-10.9.2.tgz",
+			"integrity": "sha512-2P4SQ0HrLQ+fw6llpLnOaGAvN2Zu6778SJMrCUwns4fOoG9ayrTiZk3VV8sCPkVZF8ab0zksVpS8FDY5pRCNBA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"async": "^3.2.3",
+				"chalk": "^4.0.2",
+				"filelist": "^1.0.4",
+				"minimatch": "^3.1.2"
+			},
+			"bin": {
+				"jake": "bin/cli.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/jake/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/jake/node_modules/brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/jake/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/jake/node_modules/minimatch": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/jest": {
@@ -7322,10 +6075,10 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/lodash.debounce": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-			"integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+		"node_modules/lodash.memoize": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+			"integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -7384,6 +6137,13 @@
 			"engines": {
 				"node": ">=10"
 			}
+		},
+		"node_modules/make-error": {
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+			"dev": true,
+			"license": "ISC"
 		},
 		"node_modules/makeerror": {
 			"version": "1.0.12",
@@ -8268,80 +7028,12 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/regenerate": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
-			"integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/regenerate-unicode-properties": {
-			"version": "10.2.0",
-			"resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.2.0.tgz",
-			"integrity": "sha512-DqHn3DwbmmPVzeKj9woBadqmXxLvQoQIwu7nopMc72ztvxVmVk2SBhSnx67zuye5TP+lJsb/TBQsjLKhnDf3MA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"regenerate": "^1.4.2"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/regenerator-runtime": {
 			"version": "0.14.1",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
 			"integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/regenerator-transform": {
-			"version": "0.15.2",
-			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.15.2.tgz",
-			"integrity": "sha512-hfMp2BoF0qOk3uc5V20ALGDS2ddjQaLrdl7xrGXvAIow7qeWRM2VA2HuCHkUKk9slq3VwEwLNK3DFBqDfPGYtg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.8.4"
-			}
-		},
-		"node_modules/regexpu-core": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-6.1.1.tgz",
-			"integrity": "sha512-k67Nb9jvwJcJmVpw0jPttR1/zVfnKf8Km0IPatrU/zJ5XeG3+Slx0xLXs9HByJSzXzrlz5EDvN6yLNMDc2qdnw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"regenerate": "^1.4.2",
-				"regenerate-unicode-properties": "^10.2.0",
-				"regjsgen": "^0.8.0",
-				"regjsparser": "^0.11.0",
-				"unicode-match-property-ecmascript": "^2.0.0",
-				"unicode-match-property-value-ecmascript": "^2.1.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/regjsgen": {
-			"version": "0.8.0",
-			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.8.0.tgz",
-			"integrity": "sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/regjsparser": {
-			"version": "0.11.1",
-			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.11.1.tgz",
-			"integrity": "sha512-1DHODs4B8p/mQHU9kr+jv8+wIC9mtG4eBHxWxIq5mhjE3D5oORhCc6deRKzTjs9DcfRFmj9BHSDguZklqCGFWQ==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"jsesc": "~3.0.2"
-			},
-			"bin": {
-				"regjsparser": "bin/parser"
-			}
 		},
 		"node_modules/remove-trailing-separator": {
 			"version": "1.1.0",
@@ -9567,6 +8259,68 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/ts-jest": {
+			"version": "29.2.5",
+			"resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.2.5.tgz",
+			"integrity": "sha512-KD8zB2aAZrcKIdGk4OwpJggeLcH1FgrICqDSROWqlnJXGCXK4Mn6FcdK2B6670Xr73lHMG1kHw8R87A0ecZ+vA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"bs-logger": "^0.2.6",
+				"ejs": "^3.1.10",
+				"fast-json-stable-stringify": "^2.1.0",
+				"jest-util": "^29.0.0",
+				"json5": "^2.2.3",
+				"lodash.memoize": "^4.1.2",
+				"make-error": "^1.3.6",
+				"semver": "^7.6.3",
+				"yargs-parser": "^21.1.1"
+			},
+			"bin": {
+				"ts-jest": "cli.js"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0"
+			},
+			"peerDependencies": {
+				"@babel/core": ">=7.0.0-beta.0 <8",
+				"@jest/transform": "^29.0.0",
+				"@jest/types": "^29.0.0",
+				"babel-jest": "^29.0.0",
+				"jest": "^29.0.0",
+				"typescript": ">=4.3 <6"
+			},
+			"peerDependenciesMeta": {
+				"@babel/core": {
+					"optional": true
+				},
+				"@jest/transform": {
+					"optional": true
+				},
+				"@jest/types": {
+					"optional": true
+				},
+				"babel-jest": {
+					"optional": true
+				},
+				"esbuild": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/ts-jest/node_modules/semver": {
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+			"integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/type-detect": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -9646,50 +8400,6 @@
 			"integrity": "sha512-xtFJHudx8S2DSoujjMd1WeWvn7KKWFRESZTMeL1RptAYERu29D6jphMjjY+vn96jvN3kVPDNxU/E13VTaXj6jg==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/unicode-canonical-property-names-ecmascript": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.1.tgz",
-			"integrity": "sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/unicode-match-property-ecmascript": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz",
-			"integrity": "sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"unicode-canonical-property-names-ecmascript": "^2.0.0",
-				"unicode-property-aliases-ecmascript": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/unicode-match-property-value-ecmascript": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.2.0.tgz",
-			"integrity": "sha512-4IehN3V/+kkr5YeSSDDQG8QLqO26XpL2XP3GQtqwlT/QYSECAwFztxVHjlbh0+gjJ3XmNLS0zDsbgs9jWKExLg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/unicode-property-aliases-ecmascript": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz",
-			"integrity": "sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
-			}
 		},
 		"node_modules/universalify": {
 			"version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -32,15 +32,11 @@
 	"author": "",
 	"license": "ISC",
 	"devDependencies": {
-		"@babel/core": "^7.25.2",
-		"@babel/preset-env": "^7.25.4",
-		"@babel/preset-typescript": "^7.24.7",
 		"@biomejs/biome": "1.9.4",
 		"@testing-library/dom": "^10.4.0",
 		"@testing-library/jest-dom": "^6.5.0",
 		"@testing-library/user-event": "^14.5.2",
-		"@types/jest": "^29.5.13",
-		"babel-jest": "^29.7.0",
+		"@types/jest": "^29.5.14",
 		"glob": "^11.0.0",
 		"gulp": "^5.0.0",
 		"gulp-cli": "^3.0.0",
@@ -51,6 +47,7 @@
 		"sass-true": "^8.0.0",
 		"stylelint": "^16.8.1",
 		"stylelint-config-standard-scss": "^13.1.0",
-		"typescript": "^5.6.2"
+		"ts-jest": "^29.2.5",
+		"typescript": "^5.7.2"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
 	"name": "@lookupdaily/styles",
 	"version": "2.0.2",
 	"description": "My style library and utilities",
+	"type": "module",
 	"main": "dist/index.css",
 	"sass": "dist/index.scss",
 	"css": "dist/index.css",

--- a/src/components/header/header-config.ts
+++ b/src/components/header/header-config.ts
@@ -1,0 +1,13 @@
+export interface HeaderConfig {
+	moduleName: string;
+	buttonId: string;
+	menuId: string;
+	expandedClassName: string;
+}
+
+export const defaultConfig: HeaderConfig = {
+	moduleName: "ld-header",
+	buttonId: "ld-menu-button",
+	menuId: "ld-menu",
+	expandedClassName: "expanded",
+};

--- a/src/components/header/header.json
+++ b/src/components/header/header.json
@@ -1,6 +1,0 @@
-{
-	"moduleName": "ld-header",
-	"buttonId": "ld-menu-button",
-	"menuId": "ld-menu",
-	"expandedClassName": "expanded"
-}

--- a/src/components/header/header.spec.ts
+++ b/src/components/header/header.spec.ts
@@ -4,7 +4,7 @@
 
 import { getAllByRole, getByRole } from "@testing-library/dom";
 import userEvent, { type UserEvent } from "@testing-library/user-event";
-import { Header } from "./header";
+import { Header } from "./header.js";
 import "@testing-library/jest-dom";
 import "@testing-library/jest-dom/jest-globals";
 

--- a/src/components/header/header.ts
+++ b/src/components/header/header.ts
@@ -1,6 +1,6 @@
 import { getElement } from "../../tools/getElement";
 import { getModule } from "../../tools/getModule";
-import headerConfig from "./header.json";
+import { type HeaderConfig, defaultConfig } from "./header-config.js";
 
 export class Header {
 	private readonly config: HeaderConfig;
@@ -54,16 +54,9 @@ export class Header {
 		}
 	}
 
-	static init(config: HeaderConfig = headerConfig): void {
+	static init(config: HeaderConfig = defaultConfig): void {
 		const headerElement = getModule(document, config.moduleName);
 		const header = new Header(headerElement, config);
 		header.init();
 	}
-}
-
-export interface HeaderConfig {
-	moduleName: string;
-	buttonId: string;
-	menuId: string;
-	expandedClassName: string;
 }

--- a/src/components/header/header.ts
+++ b/src/components/header/header.ts
@@ -1,5 +1,5 @@
-import { getElement } from "../../tools/getElement";
-import { getModule } from "../../tools/getModule";
+import { getElement } from "../../tools/getElement.js";
+import { getModule } from "../../tools/getModule.js";
 import { type HeaderConfig, defaultConfig } from "./header-config.js";
 
 export class Header {

--- a/src/tools/getElement.spec.ts
+++ b/src/tools/getElement.spec.ts
@@ -4,7 +4,7 @@
 
 import "@testing-library/jest-dom";
 import "@testing-library/jest-dom/jest-globals";
-import { getElement } from "./getElement";
+import { getElement } from "./getElement.js";
 
 describe("getElement", () => {
 	it("finds the element", () => {

--- a/src/tools/getElement.ts
+++ b/src/tools/getElement.ts
@@ -1,4 +1,4 @@
-import { getOrThrowIfNull } from "./getOrThrowIfNull";
+import { getOrThrowIfNull } from "./getOrThrowIfNull.js";
 
 export function getElement<T extends Element>(
 	parent: HTMLElement,

--- a/src/tools/getModule.spec.ts
+++ b/src/tools/getModule.spec.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import { getModule } from "./getModule";
+import { getModule } from "./getModule.js";
 
 describe("getModule", () => {
 	afterEach(() => {

--- a/src/tools/getModule.ts
+++ b/src/tools/getModule.ts
@@ -1,4 +1,4 @@
-import { getOrThrowIfNull } from "./getOrThrowIfNull";
+import { getOrThrowIfNull } from "./getOrThrowIfNull.js";
 
 export function getModule(parent: Document, moduleName: string): HTMLElement {
 	const element = parent.querySelector(`[data-module="${moduleName}"]`);

--- a/src/tools/getOrThrowIfNull.spec.ts
+++ b/src/tools/getOrThrowIfNull.spec.ts
@@ -1,4 +1,4 @@
-import { getOrThrowIfNull } from "./getOrThrowIfNull";
+import { getOrThrowIfNull } from "./getOrThrowIfNull.js";
 
 describe("getElement", () => {
 	afterEach(() => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,7 @@
 		"declaration": true,
 		// Include the DOM types
 		"lib": ["es2022", "dom", "dom.iterable"],
-		"types": []
+		"types": ["jest"]
 	},
 	// Include the necessary files for your project
 	"include": ["src/**/*.ts", "src/**/*.json"],


### PR DESCRIPTION
Without specifying type in the package.json, all files are treated as common JS as default. As use of modules in Node is stable, servers such as Vite are deprecating the use of CSM.

Changing the type here to ensure TypeScript is transpiled as ESM JavaScript.

With modules specified we need to add extensions to our imports, and remove any use of `require` import syntax.
We also need to switch to ts-jest which enables us to transform ESM modules for tests.