### PR TITLE
Update sass exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
 		"./header.js": "./dist/components/header/header.js",
 		"./scss": "./dist/index.scss",
 		"./scss/components": "./dist/components/index.scss",
-		"./scss/components/header": "./dist/components/header/_header.scss"
+		"./scss/components/header": "./dist/components/header/_header.scss",
+		"./sass": "./dist/index.scss",
+		"./sass/components": "./dist/components/index.scss",
+		"./sass/components/header": "./dist/components/header/_header.scss"
 	},
 	"files": ["dist/", "package.json", "README.md", "index.css", "index.css.map"],
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lookupdaily/styles",
-	"version": "2.0.2",
+	"version": "2.0.3",
 	"description": "My style library and utilities",
 	"type": "module",
 	"main": "dist/index.css",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		".": "./index.css",
 		"./header": "./dist/components/header/header.js",
 		"./header.js": "./dist/components/header/header.js",
-		"./scss/": "./dist/index.scss",
+		"./scss": "./dist/index.scss",
 		"./scss/components": "./dist/components/index.scss",
 		"./scss/components/header": "./dist/components/header/_header.scss"
 	},


### PR DESCRIPTION
In local development it is hard to test the `/scss` export, as there is an `/scss` directory in the library (which is not packaged). Adding a differently named export path to make this easier to check.
