### PR TITLE
Fix font type

### DIFF
--- a/scss/settings/_typography.scss
+++ b/scss/settings/_typography.scss
@@ -40,7 +40,7 @@ $fonts: (
   subtitle: (
     family: (
       $title-font,
-      sans-serif,
+      serif,
     ),
     weight: 400,
     size: "larger",


### PR DESCRIPTION
In #87 I changed the font for 'subtitle' text to a serif font to match the headings. However, I neglected to update `sans-serif` in the font family to `serif`, which is causing an incorrect fallback in Android's firefox browser.