### PR TITLE
Fix build not erroring in CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
 	},
 	"files": ["dist/", "package.json", "README.md", "index.css", "index.css.map"],
 	"scripts": {
-		"build:scss": "sass scss/index.scss index.css --style=compressed & npx gulp",
+		"build:scss": "sass scss/index.scss index.css --style=compressed && npx gulp",
 		"build:typescript": "npx tsc",
-		"build": "npm run build:scss & npm run build:typescript",
+		"build": "npm run build:scss && npm run build:typescript",
 		"start:scss": "sass scss/index.scss index.css --watch  & npx gulp",
 		"start:typescript": "npx tsc --watch",
 		"start": "npm run start:scss & npm run start:typescript",

--- a/scss/imports/index.scss
+++ b/scss/imports/index.scss
@@ -1,2 +1,1 @@
-@use "fonts";
 @use "normalize";


### PR DESCRIPTION
The previous release contained a build error from deleting a scss file and not it's import. This should have been caught by the `Build and test` workflow in the pull request checks.

Updating the npm scripts to use sequential tasks rather than parallel ones, which catches the error appropriately.

This change also fixes the error.