### PR TITLE
Update footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ The header should contain no more than 4 links.
 Example: 
 
 ```html
-<header class="ld-header {% if pageType == 'home' %}home{% endif %}" data-module="ld-header">
+<header class="ld-header data-module="ld-header">
   <div class="visually-hidden"><a href="#content">Skip to content</a></div>
   <div class="ld-logo"><a href="/" class="ld-logo__link">{ logo }</a></div>
   <span hidden id="menu-label">Main menu</span>

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This repository and package contain a set of styles that Liz Daly uses across he
       - [Sizes](#sizes)
   - [Components](#components)
     - [Header](#header)
+    - [Footer](#footer)
   - [Local development](#local-development)
     - [Requirements](#requirements)
     - [Getting started](#getting-started)
@@ -178,6 +179,48 @@ const config = {
 document.addEventListener("DOMContentLoaded", () => {
   Header.init(config);
 })
+```
+
+### Footer
+
+Content can be across one or two columns, against secondary colour background. On smaller screens there will always be one column.
+
+For one column, set content directly in the footer class:
+
+```html
+<footer class="ld-footer">
+  <p>Footer content</p>
+</footer>
+```
+
+For two, add `__content` class containing two elements only:
+
+```html
+<footer class="ld-footer">
+  <div class="ld-footer__content">
+    <p>
+      Left column
+    </p>
+    <p>
+      Right column
+    </p>
+  </div>
+</footer>
+```
+
+To align items to the left and right edges add `__item--justify-outside` to each element:
+
+```html
+<footer class="ld-footer">
+  <div class="ld-footer__content">
+    <p class="ld-footer__item--justify-outside">
+      Left-aligned content
+    </p>
+    <p class="ld-footer__item--justify-outside">
+      Right-aligned content
+    </p>
+  </div>
+</footer>
 ```
 
 ## Local development

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lookupdaily/styles",
-	"version": "2.0.6",
+	"version": "2.1.0",
 	"description": "My style library and utilities",
 	"type": "module",
 	"main": "dist/index.css",

--- a/scss/components/_footer.scss
+++ b/scss/components/_footer.scss
@@ -15,7 +15,7 @@
 
   &__content {
     display: grid;
-    align-items: center;
+    align-items: flex-start;
     max-width: 1100px;
     margin: 0 auto;
   }
@@ -38,6 +38,15 @@
   .ld-footer {
     &__content {
       grid-template-columns: 1fr 1fr;
+    }
+
+    &__item:first-child {
+      justify-self: flex-start;
+    }
+
+    &__item:last-child {
+      justify-self: flex-end;
+      text-align: end;
     }
 
     &__credit {


### PR DESCRIPTION
Add new item class which can be used for a footer to justify columns to opposite ends of the screen on larger screens.
Also align content to the top of the footer rather than in the centre vertically.

Example usage:
```html
<footer class="ld-footer">
  <div class="ld-footer__content">
    <p class="ld-footer__item--justify-outside">
      Left-aligned text
    </p>
    <p class="ld-footer__item--justify-outside">
      Right-aligned text
    </p>
  </div>
</footer>
```