### PR TITLE
Add markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ If your project uses sass you can import all styles, or individual modules
 
 ## Styles
 
+Styles are written in the [BEM pattern](https://getbem.com/naming/) and applied using classes, but can also be applied directly to relevant html elements (without the need for classes) by wrapping a page in the class `ld-md`. This is designed for use with markdown templates where elements will not be individually styled with classes.  
+
 ### Colour
 
 Colours are available via global css-variables or utility classes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lookupdaily/styles",
-	"version": "2.1.0",
+	"version": "2.2.0",
 	"description": "My style library and utilities",
 	"type": "module",
 	"main": "dist/index.css",

--- a/scss/components/_link.scss
+++ b/scss/components/_link.scss
@@ -2,7 +2,7 @@
 
 /* Link Styles */
 
-.ld-link {
+.ld-link, .ld-md a {
   @include colour.text-colour("primary");
 
   padding: 0 0.3rem 0.12rem;
@@ -14,23 +14,13 @@
     align-items: center;
   }
 
-  a {
-    padding: 0;
-  }
-
-  &:visited,
-  a:visited {
+  &:visited {
     @include colour.text-colour("primary");
   }
 
   &:hover,
   &:focus {
     @include colour.background-colour("primary");
-
-    a {
-      background-color: transparent;
-      color: inherit;
-    }
   }
 
   &[data-state="active"] {
@@ -59,5 +49,23 @@
   &--hover-underline:hover {
     background-color: transparent;
     border-bottom: 3px solid var(--ld-colour-secondary);
+  }
+}
+
+.ld-link{
+  a {
+    padding: 0;
+  }
+
+  &:hover,
+  &:focus {
+    a {
+      background-color: transparent;
+      color: inherit;
+    }
+  }
+
+  a:visited {
+    @include colour.text-colour("primary");
   }
 }

--- a/scss/components/_link.scss
+++ b/scss/components/_link.scss
@@ -5,7 +5,7 @@
 .ld-link {
   @include colour.text-colour("primary");
 
-  padding: 0 0.3rem;
+  padding: 0 0.3rem 0.12rem;
   margin: 0 -0.3rem;
   border-radius: 2px;
 

--- a/scss/components/_lists.scss
+++ b/scss/components/_lists.scss
@@ -3,7 +3,7 @@
 
 /* List styles */
 
-.ld-descriptive-list {
+.ld-descriptive-list, .ld-md dl  {
   dt {
     font-weight: 500;
   }
@@ -20,7 +20,7 @@
 }
 
 @media (width >= $small-breakpoint) {
-  .ld-descriptive-list {
+  .ld-descriptive-list, .ld-md dl {
     display: grid;
     grid-template-columns: max-content auto;
     gap: spacing.get("large");

--- a/scss/elements/_break.scss
+++ b/scss/elements/_break.scss
@@ -1,0 +1,8 @@
+@use "../tools/border";
+@use "../tools/spacing";
+
+.ld-break, .ld-md hr {
+  @include border.border;
+  @include spacing.margin-bottom("x-large");
+  @include spacing.margin-top("x-large");
+}

--- a/scss/elements/_typography.scss
+++ b/scss/elements/_typography.scss
@@ -1,5 +1,6 @@
 @use "../tools/typography";
 @use "../tools/colour";
+@use "../tools/spacing";
 
 small {
   @include typography.font-size("small");
@@ -27,6 +28,8 @@ h2 {
 }
 
 h3 {
+  @include spacing.margin-bottom("x-small");
+
   font-weight: 500;
 }
 

--- a/scss/elements/index.scss
+++ b/scss/elements/index.scss
@@ -1,4 +1,5 @@
 @use "root";
 @use "html";
 @use "body";
+@use "break";
 @use "typography";

--- a/scss/tools/_border.scss
+++ b/scss/tools/_border.scss
@@ -1,0 +1,7 @@
+@mixin border-top($width: 5px) {
+  border-top: $width solid var(--ld-colour-secondary);
+}
+
+@mixin border($width: 2.5px) {
+  border: $width solid var(--ld-colour-secondary);
+}

--- a/scss/tools/_border.test.scss
+++ b/scss/tools/_border.test.scss
@@ -1,0 +1,70 @@
+@use "true" as *;
+@use "border";
+
+@include describe("border mixin") {
+  @include it("sets border to default width") {
+    @include assert {
+      @include output {
+        .box {
+          @include border.border;
+        }
+      }
+
+      @include expect {
+        .box {
+          border: 2.5px solid var(--ld-colour-secondary);
+        }
+      }
+    }
+  }
+
+  @include it("sets border to provided width") {
+    @include assert {
+      @include output {
+        .box {
+          @include border.border(3px);
+        }
+      }
+
+      @include expect {
+        .box {
+          border: 3px solid var(--ld-colour-secondary);
+        }
+      }
+    }
+  }
+}
+
+@include describe("border top mixin") {
+  @include it("sets border top to default width") {
+    @include assert {
+      @include output {
+        .box {
+          @include border.border-top;
+        }
+      }
+
+      @include expect {
+        .box {
+          border-top: 5px solid var(--ld-colour-secondary);
+        }
+      }
+    }
+  }
+
+  @include it("sets border to provided width") {
+    @include assert {
+      @include output {
+        .box {
+          @include border.border-top(3px);
+        }
+      }
+
+      @include expect {
+        .box {
+          border-top: 3px solid var(--ld-colour-secondary);
+        }
+      }
+    }
+  }
+}

--- a/scss/tools/index.scss
+++ b/scss/tools/index.scss
@@ -1,3 +1,4 @@
 @forward "typography" hide get-variables, create-classes, get-size, get-weight;
 @forward "colour" hide get-variables, create-classes;
 @forward "spacing";
+@forward "border";

--- a/scss/utilities/_border.scss
+++ b/scss/utilities/_border.scss
@@ -1,3 +1,5 @@
+@use "../tools/border";
+
 .ld-border-top--secondary {
-  border-top: 5px solid var(--ld-colour-secondary);
+  @include border.border-top;
 }


### PR DESCRIPTION
This adds the ability to bypass classes for applying styling, for use with markdown templates. Styles can be styled to equivalent html elements when wrapped with the class `ld-md`.

Also adds a new 'break' component for use with the `hr` [thematic break](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hr) element.