### PR TITLE
Fix link colour

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lookupdaily/styles",
-	"version": "2.2.0",
+	"version": "2.2.1",
 	"description": "My style library and utilities",
 	"type": "module",
 	"main": "dist/index.css",

--- a/scss/components/_link.scss
+++ b/scss/components/_link.scss
@@ -57,15 +57,15 @@
     padding: 0;
   }
 
+  a:visited {
+    @include colour.text-colour("primary");
+  }
+
   &:hover,
   &:focus {
     a {
       background-color: transparent;
       color: inherit;
     }
-  }
-
-  a:visited {
-    @include colour.text-colour("primary");
   }
 }


### PR DESCRIPTION
When moving style declarations for links with a class applied to a parent element, I copied them in the wrong order, meaning that a visited link colour took precedence over hover.